### PR TITLE
Hotfix/Tmp timestamps support

### DIFF
--- a/src/views/data-workflows/gbq-to-gcs/configurations/ItemView.vue
+++ b/src/views/data-workflows/gbq-to-gcs/configurations/ItemView.vue
@@ -277,7 +277,7 @@ export default class GbqToGcsConfigurationsItemView extends Mixins(HeaderInfosMi
 					],
 					rows: [
 						{
-							update_date: this.item.update_date,
+							update_date: this.item.update_date || this.item.updated_date,
 							updated_by: this.item.updated_by,
 							creation_date: this.item.creation_date,
 							created_by: this.item.created_by

--- a/src/views/data-workflows/gbq-to-gcs/runs/ItemView.vue
+++ b/src/views/data-workflows/gbq-to-gcs/runs/ItemView.vue
@@ -334,7 +334,7 @@ export default class GbqToGcsRunsItemView extends Mixins(HeaderInfosMixin, ItemM
 				component: 'create-update-conf-overview',
 				props: {
 					creationDate: this.item.configuration_context.creation_date,
-					updateDate: this.item.configuration_context.update_date,
+					updateDate: this.item.configuration_context.update_date || this.item.configuration_context.updated_date,
 					createdBy: this.item.configuration_context.created_by,
 					updatedBy: this.item.configuration_context.updated_by
 				}

--- a/src/views/data-workflows/gcs-to-gcs/runs/ItemView.vue
+++ b/src/views/data-workflows/gcs-to-gcs/runs/ItemView.vue
@@ -348,7 +348,7 @@ export default class GcsToGcsRunsItemView extends Mixins(HeaderInfosMixin, ItemM
 				component: 'create-update-conf-overview',
 				props: {
 					creationDate: this.item.configuration_context.creation_date,
-					updateDate: this.item.configuration_context.update_date,
+					updateDate: this.item.configuration_context.update_date || this.item.configuration_context.updated_date,
 					createdBy: this.item.configuration_context.created_by,
 					updatedBy: this.item.configuration_context.updated_by
 				}

--- a/src/views/data-workflows/storage-to-table/configurations/ItemView.vue
+++ b/src/views/data-workflows/storage-to-table/configurations/ItemView.vue
@@ -294,7 +294,7 @@ export default class StorageToTableConfigurationsItemView extends Mixins(HeaderI
 				component: 'create-update-conf-overview',
 				props: {
 					creationDate: this.item.creation_date,
-					updateDate: this.item.update_date,
+					updateDate: this.item.update_date || this.item.updated_date,
 					createdBy: this.item.created_by,
 					updatedBy: this.item.updated_by
 				}

--- a/src/views/data-workflows/storage-to-table/runs/ItemView.vue
+++ b/src/views/data-workflows/storage-to-table/runs/ItemView.vue
@@ -417,7 +417,7 @@ export default class StorageToTableRunsItemView extends Mixins(HeaderInfosMixin,
 				component: 'create-update-conf-overview',
 				props: {
 					creationDate: this.item.configuration_context.creation_date,
-					updateDate: this.item.configuration_context.update_date,
+					updateDate: this.item.configuration_context.update_date || this.item.configuration_context.updated_date,
 					createdBy: this.item.configuration_context.created_by,
 					updatedBy: this.item.configuration_context.updated_by
 				}

--- a/src/views/data-workflows/storage-to-tables/configurations/ItemView.vue
+++ b/src/views/data-workflows/storage-to-tables/configurations/ItemView.vue
@@ -276,7 +276,7 @@ export default class StorageToTablesConfigurationsItemView extends Mixins(Header
 				component: 'create-update-conf-overview',
 				props: {
 					creationDate: null,
-					updateDate: this.item.updated_date,
+					updateDate: this.item.update_date || this.item.updated_date,
 					createdBy: null,
 					updatedBy: this.item.updated_by
 				}

--- a/src/views/data-workflows/storage-to-tables/runs/ItemView.vue
+++ b/src/views/data-workflows/storage-to-tables/runs/ItemView.vue
@@ -387,7 +387,7 @@ export default class StorageToTablesRunsItemView extends Mixins(HeaderInfosMixin
 				component: 'create-update-conf-overview',
 				props: {
 					creationDate: this.item.configuration_context.creation_date,
-					updateDate: this.item.configuration_context.update_date,
+					updateDate: this.item.configuration_context.update_date || this.item.configuration_context.updated_date,
 					createdBy: this.item.configuration_context.created_by,
 					updatedBy: this.item.configuration_context.updated_by
 				}

--- a/src/views/data-workflows/table-to-storage/configurations/ItemView.vue
+++ b/src/views/data-workflows/table-to-storage/configurations/ItemView.vue
@@ -255,7 +255,7 @@ export default class TableToStorageConfigurationsItemView extends Mixins(HeaderI
 					],
 					rows: [
 						{
-							update_date: this.item.update_date,
+							update_date: this.item.update_date || this.item.updated_date,
 							updated_by: this.item.updated_by,
 							creation_date: this.item.creation_date,
 							created_by: this.item.created_by

--- a/src/views/data-workflows/table-to-storage/runs/ItemView.vue
+++ b/src/views/data-workflows/table-to-storage/runs/ItemView.vue
@@ -334,7 +334,7 @@ export default class TableToStorageRunsItemView extends Mixins(HeaderInfosMixin,
 				component: 'create-update-conf-overview',
 				props: {
 					creationDate: this.item.configuration_context.creation_date,
-					updateDate: this.item.configuration_context.update_date,
+					updateDate: this.item.configuration_context.update_date || this.item.configuration_context.updated_date,
 					createdBy: this.item.configuration_context.created_by,
 					updatedBy: this.item.configuration_context.updated_by
 				}

--- a/src/views/data-workflows/tables-to-tables/configurations/ItemView.vue
+++ b/src/views/data-workflows/tables-to-tables/configurations/ItemView.vue
@@ -160,7 +160,7 @@ export default class TablesToTablesConfigurationsItemView extends Mixins(HeaderI
 				component: 'create-update-conf-overview',
 				props: {
 					creationDate: this.item.creation_date,
-					updateDate: this.item.update_date,
+					updateDate: this.item.update_date || this.item.updated_date,
 					createdBy: this.item.created_by,
 					updatedBy: this.item.updated_by
 				}


### PR DESCRIPTION
[comment]: [![Status](https://img.shields.io/badge/Status-DEVELOPMENT-orange.svg)]()
[comment]: [![Status](https://img.shields.io/badge/Status-HOLD-inactive.svg)]()

[![Status](https://img.shields.io/badge/Status-READY-brightgreen.svg)]()


## Description
Fix `CreateUpdateConfOverview` timestamps support


## Todos
- [x] Support `update_date` & `updated_date`


## Deploy Notes
Review & merge.


## Steps to Test or Reproduce
```sh
git checkout master
git pull
git checkout hotfix/creation-date-and-update-date
```

1. Try `update_date` => [here](http://localhost:8080/data-workflows/gcs-to-gcs/runs/3591639a-28bc-468b-ae86-d0726bedeeb0__2020-01-14T10:24:35.013Z)
2. Try `updated_date` => [here](http://localhost:8080/data-workflows/storage-to-tables/runs/20200114-41b236b7-0bb4-4300-9c94-79a8435bbccb)


## Impacted Areas in Application
All `ItemView` using `src/components/data-workflows/configuration/CreateUpdateConfOverview.vue`
