### PR TITLE
Hotfix/Clear persisted store data on sign in

### DIFF
--- a/src/constants/store/vuex-persist.ts
+++ b/src/constants/store/vuex-persist.ts
@@ -1,0 +1,1 @@
+export const KEY = 'vuex';

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,7 @@ import { userModule } from './modules/user';
 import { filtersModule } from './modules/filters';
 import easyFirestoreModules from './modules/easy-firestore';
 import { firebase, initFirebase } from '../config/firebase';
+import { KEY } from '@/constants/store/vuex-persist';
 
 initFirebase().catch(error => {
 	console.error(error);
@@ -21,8 +22,8 @@ const easyFirestore = VuexEasyFirestore(easyFirestoreModules, {
 	preventInitialDocInsertion: true
 });
 
-const vuexLocalStorage = new VuexPersist({
-	key: 'vuex',
+const vuexPersist = new VuexPersist({
+	key: KEY,
 	storage: window.localStorage,
 	reducer: (state: any) => ({
 		filters: state.filters
@@ -31,7 +32,7 @@ const vuexLocalStorage = new VuexPersist({
 
 const storeOptions: StoreOptions<RootState> = {
 	modules: { user: userModule, filters: filtersModule },
-	plugins: [easyFirestore, vuexLocalStorage.plugin]
+	plugins: [easyFirestore, vuexPersist.plugin]
 };
 
 export default new Vuex.Store<RootState>(storeOptions);

--- a/src/views/auth/SignIn.vue
+++ b/src/views/auth/SignIn.vue
@@ -85,6 +85,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { InputValidationRules } from 'vuetify';
+import { KEY } from '@/constants/store/vuex-persist';
 
 type Model = {
 	email: string;
@@ -106,6 +107,10 @@ export default class SignIn extends Vue {
 		v => !!v || 'Password is required',
 		v => v.length >= 6 || 'Password must be greater than 6 characters'
 	];
+
+	mounted() {
+		localStorage.removeItem(KEY);
+	}
 
 	googleSignIn() {
 		this.loadingGoogleSignIn = true;


### PR DESCRIPTION
[comment]: [![Status](https://img.shields.io/badge/Status-DEVELOPMENT-orange.svg)]()
[comment]: [![Status](https://img.shields.io/badge/Status-HOLD-inactive.svg)]()

[![Status](https://img.shields.io/badge/Status-READY-brightgreen.svg)]()


## Description
Clear persisted store data on sign in to avoid roles issues.


## Todos
- [x] Clear data when user is in sign-in page


## Deploy Notes
Review & merge


## Steps to Test or Reproduce
```sh
git checkout master
git pull
git checkout hotfix/vuex-persist
```

1. Log in with a super admin user and go to a configurations listing => `Archived` status should be present.
2. Log in with a non admin or super admin account => `Archived` status should not be present and `vuex` data persisted in `localStorage` should be cleared.


## Impacted Areas in Application
- `src/views/auth/SignIn.vue`
