### PR TITLE
fix(SignIn): Removed lazy-validation on form

### DIFF
--- a/src/views/auth/SignIn.vue
+++ b/src/views/auth/SignIn.vue
@@ -18,7 +18,7 @@
 								A secure, intelligent, useful Big Data platform designed from scratch to address the fashion issues.
 							</p>
 
-							<v-form ref="form" v-model="valid" lazy-validation>
+							<v-form ref="form" v-model="valid">
 								<v-text-field
 									name="login"
 									label="Login"


### PR DESCRIPTION
[comment]: [![Status](https://img.shields.io/badge/Status-DEVELOPMENT-orange.svg)]()
[comment]: [![Status](https://img.shields.io/badge/Status-HOLD-inactive.svg)]()

[![Status](https://img.shields.io/badge/Status-READY-brightgreen.svg)]()


## Description
Fix sign in btn disable status.


## Todos
- [x] Remove lazy-validation prop on `v-form`


## Deploy Notes
Review & merge


## Steps to Test or Reproduce
```sh
git checkout master
git pull
git checkout hotfix/sign-in-hero-img-on-build
```

1. Go to `/sign-in` and the "Sign in" btn should be disable while form is not valid.


## Impacted Areas in Application
List general components of the application that this PR will affect:
- `src/views/auth/SignIn.vue`
