### PR TITLE
fix(listing): Fixed search for storage-to-tables

### DIFF
--- a/src/components/data-workflows/storage-to-tables/runs/CollectionListing.vue
+++ b/src/components/data-workflows/storage-to-tables/runs/CollectionListing.vue
@@ -48,7 +48,7 @@ export default class CollectionListing extends Mixins(RunCollectionMixin) {
 				{
 					text: 'Source Storage',
 					sortable: true,
-					value: 'configuration_context.source'
+					value: 'source_storage'
 				},
 				{
 					text: 'Destinations',


### PR DESCRIPTION
Closes #197 

## Description
Fix listing search for `storage-to-tables`

## Todos
- [x] Update `value` property for source storage header


## Deploy Notes
Review & merge


## Steps to Test or Reproduce
1. Go to https://jarvis-platform.io/data-workflows/storage-to-tables/runs
2. Copy/Paste the name of the first Source Storage of the first Run
3. Paste the name in the search bar => 🎉


## Impacted Areas in Application
List general components of the application that this PR will affect:

* `src/components/data-workflows/storage-to-tables/runs/CollectionListing.vue`
