### PR TITLE
Add tab `Run Logs` into storage-to-storage & storage-to-tables

### DIFF
--- a/src/components/data-workflows/common/item/imported-components.ts
+++ b/src/components/data-workflows/common/item/imported-components.ts
@@ -1,5 +1,6 @@
 import AvatarComponent from '@/components/common/AvatarComponent.vue';
 import HistoryComponent from '@/components/data-workflows/common/item/HistoryComponent.vue';
+import LogsComponent from '@/components/data-workflows/common/item/logs/LogsComponent.vue';
 import OtherRuns from './other-runs/OtherRuns.vue';
 import OverviewComponent from './overview/OverviewComponent.vue';
 import TableSchemaView from '@/components/data-workflows/common/item/schema/TableSchemaView.vue';
@@ -10,6 +11,7 @@ import NotesTab from './notes/NotesTab.vue';
 export default {
 	AvatarComponent,
 	HistoryComponent,
+	LogsComponent,
 	OverviewComponent,
 	OtherRuns,
 	TableSchemaView,

--- a/src/components/data-workflows/common/item/logs/LogsComponent.vue
+++ b/src/components/data-workflows/common/item/logs/LogsComponent.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="pt-6">
+	<v-container class="py-6">
 		<div v-if="isLoading" class="text-center">
 			<v-progress-circular indeterminate size="42" color="primary" />
 		</div>
@@ -33,7 +33,7 @@
 				</v-tab-item>
 			</v-tabs>
 		</div>
-	</div>
+	</v-container>
 </template>
 
 <script lang="ts">
@@ -51,10 +51,10 @@ export default class LogsComponent extends Vue {
 	activeTab: null = null;
 
 	@Prop({ required: true }) private dagId!: string;
-	@Prop({ required: true }) private taskId!: string;
 	@Prop({ required: true }) private dagRunId!: string;
 	@Prop({ required: true }) private dagType!: string;
 	@Prop({ required: true }) private dagExecutionDate!: string;
+	@Prop(String) private taskId?: string;
 
 	mounted() {
 		this.getLogs();
@@ -91,7 +91,9 @@ export default class LogsComponent extends Vue {
 	}
 
 	downloadLogFile(airflowFileName: string): void {
-		const fileName = `${this.dagId}-${this.taskId}-${this.dagExecutionDate}-${airflowFileName}`;
+		const fileName = this.taskId
+			? `${this.dagId}-${this.taskId}-${this.dagExecutionDate}-${airflowFileName}`
+			: `${this.dagId}-${this.dagExecutionDate}-${airflowFileName}`;
 
 		const element = document.createElement('a');
 		element.setAttribute('href', `data:text/plain;charset=utf-8,${this.logs[airflowFileName]}`);

--- a/src/components/data-workflows/common/item/tasks/TaskItem.vue
+++ b/src/components/data-workflows/common/item/tasks/TaskItem.vue
@@ -90,6 +90,7 @@
 									:dag-run-id="getLogsProps.dagRunId"
 									:dag-type="getLogsProps.dagType"
 									:dag-execution-date="getLogsProps.dagExecutionDate"
+									class="px-0"
 								/>
 							</v-card-text>
 

--- a/src/mixins/data-workflows/doc/run-doc-mixin.ts
+++ b/src/mixins/data-workflows/doc/run-doc-mixin.ts
@@ -1,14 +1,5 @@
 import { Component } from 'vue-property-decorator';
-import {
-	ConfigurationTab,
-	DataItem,
-	DataWorkflowsType,
-	FullJSONTab,
-	NotesTab,
-	OtherRunTab,
-	RunDetailsTab,
-	RunProps
-} from '@/types';
+import { DataItem, DataWorkflowsType, OtherRunTab, RunDetailsTab, RunLogsTab, RunProps } from '@/types';
 import DocMixin from '@/mixins/data-workflows/doc/doc-mixin';
 import { RUNS } from '@/constants/data-workflows/status';
 
@@ -37,11 +28,27 @@ export default class RunDocMixin extends DocMixin {
 	get runDetailsTab(): RunDetailsTab {
 		return {
 			label: 'Run Details',
-			href: 'run-details',
+			href: 'run-logs',
 			component: {
 				name: 'overview-component',
 				props: {
 					data: this.runDetailsData
+				}
+			}
+		};
+	}
+
+	get runLogsTab(): RunLogsTab {
+		return {
+			label: 'Run Logs',
+			href: 'run-details',
+			component: {
+				name: 'logs-component',
+				props: {
+					dagId: this.item.dag_id,
+					dagRunId: this.item.dag_run_id,
+					dagType: this.item.dag_type,
+					dagExecutionDate: this.item.dag_execution_date
 				}
 			}
 		};

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -240,6 +240,18 @@ export interface RunDetailsTab extends Tab {
 	};
 }
 
+export interface RunLogsTab extends Tab {
+	component: {
+		name: string;
+		props: {
+			dagId: string;
+			dagRunId: string;
+			dagType: string;
+			dagExecutionDate: string;
+		};
+	};
+}
+
 export interface OtherRunTab extends Tab {
 	component: {
 		name: string;

--- a/src/views/data-workflows/storage-to-storage/runs/ItemView.vue
+++ b/src/views/data-workflows/storage-to-storage/runs/ItemView.vue
@@ -176,6 +176,18 @@ export default class StorageToStorageRunsItemView extends Mixins(HeaderInfosMixi
 		return destinationStorageRows;
 	}
 
+	get itemTabsItems(): any {
+		if (Object.keys(this.item).length === 0) return [];
+		return [
+			this.runDetailsTab,
+			this.runLogsTab,
+			this.configurationTab,
+			this.fullJSONTab,
+			this.otherRunsTab,
+			this.notesTab
+		];
+	}
+
 	get runDetailsData() {
 		return [
 			{

--- a/src/views/data-workflows/storage-to-tables/runs/ItemView.vue
+++ b/src/views/data-workflows/storage-to-tables/runs/ItemView.vue
@@ -170,6 +170,18 @@ export default class StorageToTablesRunsItemView extends Mixins(HeaderInfosMixin
 		];
 	}
 
+	get itemTabsItems(): any {
+		if (Object.keys(this.item).length === 0) return [];
+		return [
+			this.runDetailsTab,
+			this.runLogsTab,
+			this.configurationTab,
+			this.fullJSONTab,
+			this.otherRunsTab,
+			this.notesTab
+		];
+	}
+
 	get runDetailsData() {
 		return [
 			{


### PR DESCRIPTION
Closes #207 


## Description
Add logs in storage-to-storage & storage-to-tables


## Todos
- [x] Adapt `LogsComponent`
- [x] Create tab
- [x] Import in views


## Deploy Notes
Review & merge


## Steps to Test or Reproduce
```sh
git checkout master
git pull
git checkout feature/logs
```

1. Go to a storage-to-storage `ItemView` => `Run Logs` + Download file
1. Go to a storage-to-tables `ItemView` => `Run Logs` + Download file


## Impacted Areas in Application
List general components of the application that this PR will affect:

* storage-to-storage
* storage-to-tables
* `LogsComponent`
