### PR TITLE
Add fix when sql property is empty in tasks listing

### DIFF
--- a/src/components/data-workflows/common/item/tasks/TaskItem.vue
+++ b/src/components/data-workflows/common/item/tasks/TaskItem.vue
@@ -11,7 +11,7 @@
 				<v-toolbar flat color="transparent">
 					<v-spacer />
 
-					<v-dialog v-model="dialogSql" max-width="1000" fullscreen v-if="task.task_type === 'sql'">
+					<v-dialog v-model="dialogSql" max-width="1000" fullscreen v-if="task.task_type === 'sql' && task.sql">
 						<template v-slot:activator="{ on }">
 							<v-chip color="orange" text-color="white" v-on="on" class="mr-2">VIEW SQL</v-chip>
 						</template>

--- a/src/components/data-workflows/common/item/tasks/TaskListing.vue
+++ b/src/components/data-workflows/common/item/tasks/TaskListing.vue
@@ -58,6 +58,8 @@ export default {
 	},
 	methods: {
 		prepareSQL(sqlFile) {
+			if (!sqlFile) return;
+
 			let sql = '';
 			if (sqlFile._binaryString !== undefined) {
 				try {


### PR DESCRIPTION
## Description
When there is no `sql` property in a `tables-to-tables` tasks tab, it broke the layout. Now we can have access to the tasks listing without the `SQL` button when there is no `sql` property.


## Todos
- [x] Return empty when `sql` property doesn't exist
- [x] Hide button in task listing when there is no `sql` property


## Deploy Notes
Review & merge


## Steps to Test or Reproduce
```sh
git checkout master
git pull
git checkout fix/task-sql-empty
```

1. Go to `/data-workflows/tables-to-tables/runs/000010_load_pda_to_bda_store_analytics_PROD_20200324-190259-9c00fb16-385f-4f7c-94f7-53c9ae20320b`
2. Go in `TASKS` tab => Listing should appear properly without the `SQL` button


## Impacted Areas in Application
* `src/components/data-workflows/common/item/tasks/TaskListing.vue`
