### PR TITLE
Fix treeview for navigation

### DIFF
--- a/src/components/data-models/TreeView.vue
+++ b/src/components/data-models/TreeView.vue
@@ -23,7 +23,7 @@
 
 <script lang="ts">
 import { Component, Vue, Watch } from 'vue-property-decorator';
-import { HOME, TABLES_LISTING } from '@/constants/router/routes-names';
+import { TABLES_LISTING } from '@/constants/router/routes-names';
 import { mapState } from 'vuex';
 
 interface TreeItem {
@@ -43,6 +43,7 @@ export default class TreeView extends Vue {
 	private dataModels: any;
 
 	active: string[] = [];
+	lastActivated: string = '';
 	open: string[] = [];
 	models: TreeItem[] = [];
 	isLoading: boolean = true;
@@ -50,15 +51,18 @@ export default class TreeView extends Vue {
 	@Watch('active')
 	onActiveChange(value: string[]) {
 		if (!value.length) {
-			this.$router.push({ name: HOME });
+			this.active = [this.lastActivated];
 			return;
 		}
 
 		const id = value[0];
-		this.$router.push({
-			name: TABLES_LISTING,
-			params: { projectId: id.split('/')[0], datasetId: id.split('/')[1] }
-		});
+		this.lastActivated = id;
+		this.$router
+			.push({
+				name: TABLES_LISTING,
+				params: { projectId: id.split('/')[0], datasetId: id.split('/')[1] }
+			})
+			.catch(err => {});
 	}
 
 	mounted() {


### PR DESCRIPTION
## Related issue(s)
<!--
Link your pull request to an issue using a keyword:
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #216 


## Description
<!-- Describe globally your PR in its context -->
Fix navigation in `data-models` treeview. Now it is not returning to the home page.


## What does this PR do?
<!-- List all stuff that have been done -->
- [x] Update active change behavior


## Deploy notes
<!-- Add additional instructions is necessary to deploy this PR -->
Review & merge.


## Steps to test or reproduce
<!-- List different steps to approve your PR -->
1. Go to the home page
2. Inside the Data Models nav, click on a project and select a dataset to view the table listing
3. Click on a Table detail view in the list
4. Click again on the Dataset in the navigation bar to go back to the table listing


## Impacted area(s) in Application
<!-- List impacted areas by being generally -->
- Navigation
